### PR TITLE
🔁(#211): link quebrado corrigido

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,5 +135,5 @@ novamente:
 
 ## 📝 Licença
 Este projeto está licenciado sob os termos da licença 
-[GNU GPL v3.0](https://github.com/fga-eps-mds/2021-1-Bot/blob/main/LICENSE).
+[GNU GPL v3.0](./LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -135,5 +135,5 @@ novamente:
 
 ## 📝 Licença
 Este projeto está licenciado sob os termos da licença 
-[GNU GPL v3.0](https://github.com/fga-eps-mds/2021-1-Bot/blob/improvement(%2398)/melhorar-readme/LICENSE).
+[GNU GPL v3.0](https://github.com/fga-eps-mds/2021-1-Bot/blob/main/LICENSE).
 


### PR DESCRIPTION
O antigo link referenciava para o arquivo "LICENSE" dentro de uma branch (que já foi excluida) e por isso estava quebrado

## O que mudou?
### Qual foi a mudança significativa para que haja um Pull Request?
- [x] Documentação atualizada
- [x] Correção de bug (mudança que **NÃO** muda funcionabilidade)

### Descrição
A issue #211 foi resolvida. Correção simples de link.

Close:

| Issue |            Título            |
|-------|:----------------------------:|
| #211 | Link de licença quebrado no readme |
    

## Lista de controle:
- [x] Você verificou se não há outras [Solicitações de Pull](https://github.com/fga-eps-mds/2021-1-Bot/pulls) para a mesma atualização/alteração?
- [x] As mudanças seguem as políticas de [commit](https://github.com/fga-eps-mds/2021-1-Bot/blob/docs_capivara/docs/politicas/commits.md) e [branch](https://github.com/fga-eps-mds/2021-1-Bot/blob/docs_capivara/docs/politicas/branches.md)
- [x] Todos os membros estão de acordo com a atualização

## Quem contribuiu?
@gatotabaco 
